### PR TITLE
Added open graph support to extract web page data and put them into Slack attachments.

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,10 +92,12 @@ func WebhookURL() string {
 	return os.Getenv("WEBHOOK_URL")
 }
 
+// SlackToken is the Slack Bot User OAuth Access Token
 func SlackToken() string {
 	return os.Getenv("SLACK_TOKEN")
 }
 
+// ChannelID is the ID of the Slack channel like `ABC8D7EFG`
 func ChannelID() string {
 	return os.Getenv("CHANNEL_ID")
 }

--- a/structs.go
+++ b/structs.go
@@ -18,11 +18,15 @@ type SlackMessageResponse struct {
 
 // SlackMessageAttachments is a struct that maps to the message attachment
 type SlackMessageAttachments struct {
-	Fallback  string                         `json:"fallback"`
-	Color     string                         `json:"color"`
-	Title     string                         `json:"title"`
-	TitleLink string                         `json:"title_link"`
-	Fields    []*SlackMessageAttachmentField `json:"fields"`
+	Fallback   string                         `json:"fallback"`
+	AuthorName string                         `json:"author_name"`
+	AuthorIcon string                         `json:"author_icon"`
+	Color      string                         `json:"color"`
+	Title      string                         `json:"title"`
+	TitleLink  string                         `json:"title_link"`
+	Fields     []*SlackMessageAttachmentField `json:"fields"`
+	ThumbURL   string                         `json:"thumb_url"`
+	Text       string                         `json:"text"`
 }
 
 // SlackMessageAttachmentField is a struct that maps to the message attachment field


### PR DESCRIPTION
This way we can make an entire story more compact.

Before:
![screen shot 2019-02-23 at 7 57 18 pm](https://user-images.githubusercontent.com/1311594/53293617-451a6500-37a5-11e9-8e89-54abd1d99cb1.png)

After:
![screen shot 2019-02-23 at 7 56 05 pm](https://user-images.githubusercontent.com/1311594/53293609-1c926b00-37a5-11e9-8602-1d9ea3202268.png)
